### PR TITLE
Enhancements to PowerShell pipeline and Azure resource management instructions

### DIFF
--- a/Instructions/Labs/LAB_AK_03A_Working_with_Windows_PowerShell_Pipeline.md
+++ b/Instructions/Labs/LAB_AK_03A_Working_with_Windows_PowerShell_Pipeline.md
@@ -7,7 +7,7 @@ lab:
 
 # Lab answer key: Using PowerShell pipeline
 
-## Exercise 1: Selecting, sorting, and displaying data
+## Exercise 1: Selecting, sorting, and displaying data using Powershell Binding
 
 ### Task 1: Display the current day of the year
 
@@ -21,13 +21,28 @@ lab:
 
    > **Note:** Notice the **Get-Date** command.
 
+1. In the console, enter the following command, to check the type of Pipeline Binding accepted by the cmdlet:
+
+   ```powershell
+   Get-Help Get-Date -Parameter * | Where-Object { $_.PipelineInput -match "true" } 
+      ```
+
+   > **Note:** Notice the **Accept pipeline input** and **Parameter set name** values.
+
+1. In the console, enter the following command, and then press the Enter key: 
+
+      ```powershell
+   Get-Date
+   ``` 
+
 1. In the console, enter the following command, and then press the Enter key:  
 
    ```powershell
    Get-Date | Get-Member
    ```
 
-   > **Note:** Notice the **DayOfYear** property.
+   > **Note:** Notice how the **(|)** allows the output of one cmdlet to be passed as input to another.
+   Notice the **DayOfYear** property.
 
 1. In the console, enter the following command, and then press the Enter key:
 
@@ -50,6 +65,15 @@ lab:
    ```
 
    > **Note:** Notice the **Get-Hotfix** command.
+
+1. In the console, enter the following command, to check the type of Pipeline Binding accepted by the cmdlet:
+
+   ```powershell
+   Get-Help Get-Hotfix -Parameter * | Where-Object { $_.PipelineInput -match "true" } 
+      ```
+
+   > **Note:** Notice the **Accept pipeline input** and **Parameter set name** values.
+
 
 1. In the console, enter the following command, and then press the Enter key:
 

--- a/Instructions/Labs/LAB_AK_09_Azure_resource_management_with_PowerShell.md
+++ b/Instructions/Labs/LAB_AK_09_Azure_resource_management_with_PowerShell.md
@@ -81,7 +81,7 @@ lab:
 
 1. In the **Welcome to Azure Cloud Shell** window, select **PowerShell**.
 
-1. On the **You have no storage mounted** page, review the note about the missing storage account that's needed for Cloud Shell to run. Verify that in the **Subscription** field, your subscription is selected, and then select **Create storage**. Wait until the storage account is created.
+1. On the **Getting started** page, ensure that the **No storage account required** option is selected, select your subscription in the **Subscription** dropdown menu, and select Apply. 
 
 1. When your storage account is created, the **Cloud Shell** console should open, and you should get a prompt in the format **PS /home/yourname>**.
 
@@ -89,7 +89,7 @@ lab:
 
 1. Enter `Get-AzResourceGroup` to review the resource group information.
 
-1. Use the drop-down list to switch from PowerShell to the **Bash** shell and confirm your choice.
+1. On the Cloud Shell page, select **Switch to Bash** and confirm your choice.
 
 1. At the Bash shell prompt, enter `az account list`, and then press the Enter key to review the information about your subscription. Also, try tab completion.
 


### PR DESCRIPTION
 
This pull request includes updates to the instructions for working with PowerShell pipelines and Azure resource management. The most important changes include clarifying task descriptions, adding commands to check pipeline binding, and updating instructions for creating storage accounts and switching shells.

Improvements to PowerShell pipeline instructions:

* [`Instructions/Labs/LAB_AK_03A_Working_with_Windows_PowerShell_Pipeline.md`](diffhunk://#diff-d4436263935660af91a32fb95d3a9292238bb0c83d48ce21990b1e5c4ed6ca2dL10-R10): Updated the title of Exercise 1 to "Selecting, sorting, and displaying data using Powershell Binding" to provide more clarity.
* [`Instructions/Labs/LAB_AK_03A_Working_with_Windows_PowerShell_Pipeline.md`](diffhunk://#diff-d4436263935660af91a32fb95d3a9292238bb0c83d48ce21990b1e5c4ed6ca2dR24-R45): Added commands to check the type of Pipeline Binding accepted by the `Get-Date` and `Get-Hotfix` cmdlets, along with notes to highlight the "Accept pipeline input" and "Parameter set name" values. [[1]](diffhunk://#diff-d4436263935660af91a32fb95d3a9292238bb0c83d48ce21990b1e5c4ed6ca2dR24-R45) [[2]](diffhunk://#diff-d4436263935660af91a32fb95d3a9292238bb0c83d48ce21990b1e5c4ed6ca2dR69-R77)
* [`Instructions/Labs/LAB_AK_03A_Working_with_Windows_PowerShell_Pipeline.md`](diffhunk://#diff-d4436263935660af91a32fb95d3a9292238bb0c83d48ce21990b1e5c4ed6ca2dR24-R45): Enhanced the note to explain how the pipeline operator `(|)` allows the output of one cmdlet to be passed as input to another.

Updates to Azure resource management instructions:

* [`Instructions/Labs/LAB_AK_09_Azure_resource_management_with_PowerShell.md`](diffhunk://#diff-8efcbf6e68e6c9851b7e9812a444295f949a4a7248bcb988215ba84a786cfc22L84-R92): Updated the instructions for creating storage accounts to select the "No storage account required" option and clarified the steps for switching from PowerShell to Bash.